### PR TITLE
fix missing tilt dependency

### DIFF
--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'redis',           '~> 3'
   s.add_dependency 'rufus-scheduler', '~> 3.1.8'
   s.add_dependency 'multi_json',      '~> 1'
+  s.add_dependency 'tilt',            '~> 2.0'
 
   s.add_development_dependency 'rake',        '~> 10.0'
   s.add_development_dependency 'timecop',     '~> 0'


### PR DESCRIPTION
was accidentally removed in this commit:

https://github.com/moove-it/sidekiq-scheduler/commit/e173071d8fb6ef7e767
fee0d6953c69449c257dd#diff-6706bb7d3bf023a73d5dd7443cb89459L25

but there are still dependencies on tilt in the code base.  If the
scheduler is a part of a rails project, tilt is already included; but
if the scheduler is not part of a rails project, then an `LoadError`
can occur.
